### PR TITLE
Fix "Invalid version string" Composer exception for dev-master plugins

### DIFF
--- a/src/Roundcube/Composer/PluginInstaller.php
+++ b/src/Roundcube/Composer/PluginInstaller.php
@@ -161,7 +161,7 @@ class PluginInstaller extends LibraryInstaller
         if (!empty($extra['roundcube'])) {
             foreach (array('min-version' => '>=', 'max-version' => '<=') as $key => $operator) {
                 if (!empty($extra['roundcube'][$key])) {
-                    $version = $parser->normalize($extra['roundcube'][$key]);
+                    $version = $parser->normalize(str_replace('-git', '.999', $extra['roundcube'][$key]));
                     $constraint = new VersionConstraint($version, $operator);
                     if (!$constraint->versionCompare($rcubeVersion, $version, $operator)) {
                         throw new \Exception("Version check failed! " . $package->getName() . " requires Roundcube version $operator $version, $rcubeVersion was detected.");


### PR DESCRIPTION
When using Composer to update plugins with a version constraint of dev-master, Composer errors out with:

[UnexpectedValueException]
Invalid version string "1.1-git"

The "-git" is already handled for the Roundcube version itself earlier in the same function:

```
    if (preg_match('/define\(.RCMAIL_VERSION.,\s*.([0-9.]+[a-z-]*)?/', $iniset, $m)) {
        $rcubeVersion = $parser->normalize(str_replace('-git', '.999', $m[1]));
    }
```
