### PR TITLE
Fix plugin_name variable declaration in install function

### DIFF
--- a/src/Roundcube/Composer/PluginInstaller.php
+++ b/src/Roundcube/Composer/PluginInstaller.php
@@ -46,9 +46,9 @@ class PluginInstaller extends LibraryInstaller
         // post-install: activate plugin in Roundcube config
         $config_file = $this->rcubeConfigFile();
         $extra = $package->getExtra();
+        $plugin_name = $this->getPluginName($package);
 
         if (is_writeable($config_file) && php_sapi_name() == 'cli') {
-            $plugin_name = $this->getPluginName($package);
             $answer = $this->io->askConfirmation("Do you want to activate the plugin $plugin_name? [N|y] ", false);
             if (true === $answer) {
                 $this->rcubeAlterConfig($plugin_name, true);


### PR DESCRIPTION
It fixes the *Undefined variable: plugin_name* exception raised by this [line](https://github.com/roundcube/plugin-installer/blob/master/src/Roundcube/Composer/PluginInstaller.php#L60) when the variable `$plugin_name` has not been declared.