### PR TITLE
Activate plugin as default action

### DIFF
--- a/src/Roundcube/Composer/PluginInstaller.php
+++ b/src/Roundcube/Composer/PluginInstaller.php
@@ -50,7 +50,7 @@ class PluginInstaller extends LibraryInstaller
         $plugin_name = $this->getPluginName($package);
 
         if (is_writeable($config_file) && php_sapi_name() == 'cli') {
-            $answer = $this->io->askConfirmation("Do you want to activate the plugin $plugin_name? [N|y] ", false);
+            $answer = $this->io->askConfirmation("Do you want to activate the plugin $plugin_name? [Y|n] ", true);
             if (true === $answer) {
                 $this->rcubeAlterConfig($plugin_name, true);
             }


### PR DESCRIPTION
Hi,
I'm trying to automate plugin installation with Docker.
Unfortanely, when I try to install a plugin by running ```composer require x/y``` from a script, I'm not able to confirm the question for activating the plugin.
I hope I didn't miss any cons!