### PR TITLE
Issue #41 - Fix skins installing into the wrong directory

### DIFF
--- a/src/Roundcube/Composer/ExtensionInstaller.php
+++ b/src/Roundcube/Composer/ExtensionInstaller.php
@@ -29,12 +29,12 @@ class ExtensionInstaller extends LibraryInstaller
      */
     public function getInstallPath(PackageInterface $package)
     {
-        static $vendorDir;
-        if ($vendorDir === null) {
-            $vendorDir = $this->getVendorDir();
+        static $vendorDir = [];
+        if (empty($vendorDir[static::class])) {
+            $vendorDir[static::class] = $this->getVendorDir();
         }
 
-        return sprintf('%s/%s', $vendorDir, $this->getPackageName($package));
+        return sprintf('%s/%s', $vendorDir[static::class], $this->getPackageName($package));
     }
 
     /**


### PR DESCRIPTION
The vendor directory into which extensions get installed is set once and subsequently cached in the ExtensionInstaller class, from which both the Plugin- and the SkinInstaller classes inherit.

This code used to work as intended, however PHP 8.1 changed the behaviour [1] and now all child classes share the static variable they inherited from their parent class. This means that when the plugin installer needs to install both regular plugins *and* skins within the same install session, the same path ends up being used both for skins and plugins, so one or the other ends up in the wrong directory.

The fix for this is based on the proposed workaround contained in the respective PHP RFC at [1].

[1] https://wiki.php.net/rfc/static_variable_inheritance