### PR TITLE
Fix dead link, replace old HTTP URLs with HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,4 +71,4 @@ Submit your plugin or skin to [Packagist](https://packagist.org/).
  * add your plugin in the `require` section of composer.json
  * `composer.phar install`
 
-Read the whole story at [plugins.roundcube.net](http://plugins.roundcube.net/about).
+Read the whole story at [plugins.roundcube.net](http://plugins.roundcube.net/#/about/).

--- a/src/Roundcube/Composer/ExtensionInstaller.php
+++ b/src/Roundcube/Composer/ExtensionInstaller.php
@@ -18,7 +18,7 @@ use React\Promise\PromiseInterface;
  * @author   Philip Weir <roundcube@tehinterweb.co.uk>
  * @license  GPL-3.0+
  * @version  GIT: <git_id>
- * @link     http://github.com/roundcube/plugin-installer
+ * @link     https://github.com/roundcube/plugin-installer
  */
 class ExtensionInstaller extends LibraryInstaller
 {

--- a/src/Roundcube/Composer/PluginInstaller.php
+++ b/src/Roundcube/Composer/PluginInstaller.php
@@ -8,7 +8,7 @@ namespace Roundcube\Composer;
  * @author   Philip Weir <roundcube@tehinterweb.co.uk>
  * @license  GPL-3.0+
  * @version  GIT: <git_id>
- * @link     http://github.com/roundcube/plugin-installer
+ * @link     https://github.com/roundcube/plugin-installer
  */
 class PluginInstaller extends ExtensionInstaller
 {

--- a/src/Roundcube/Composer/SkinInstaller.php
+++ b/src/Roundcube/Composer/SkinInstaller.php
@@ -8,7 +8,7 @@ namespace Roundcube\Composer;
  * @author   Philip Weir <roundcube@tehinterweb.co.uk>
  * @license  GPL-3.0+
  * @version  GIT: <git_id>
- * @link     http://github.com/roundcube/plugin-installer
+ * @link     https://github.com/roundcube/plugin-installer
  */
 class SkinInstaller extends ExtensionInstaller
 {


### PR DESCRIPTION
Nothing special, just found these outdated URLs while developing my first Roundcube plugin.