### PR TITLE
Require roundcube package in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         ]
     },
     "require": {
-        "composer-plugin-api": "^1.0 || ^2.0"
+        "composer-plugin-api": "^1.0 || ^2.0",
+        "roundcube/roundcubemail": "*"
     },
     "require-dev": {
         "composer/composer": "*"


### PR DESCRIPTION
This installer needs Roundcube to be installed as it rely on its globals and directories.

related with https://github.com/roundcube/roundcubemail/pull/9241