### PR TITLE
Fix install in Roundcubemail as root package

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -58,7 +58,7 @@ return (new Config())
         // also prevent bounding of unwanted variables for GC
         'use_arrow_functions' => false,
 
-        # TODO
+        // TODO
         'align_multiline_comment' => false,
         'array_indentation' => false,
         'binary_operator_spaces' => false,

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -24,14 +24,6 @@ parameters:
             path: 'src/ExtensionInstaller.php'
             count: 3
         -
-            message: '~^Call to static method db_init\(\) on an unknown class rcmail_utils\.$~'
-            path: 'src/ExtensionInstaller.php'
-            count: 1
-        -
-            message: '~^Call to static method db_update\(\) on an unknown class rcmail_utils\.$~'
-            path: 'src/ExtensionInstaller.php'
-            count: 1
-        -
             message: '~^Method Roundcube\\Composer\\ExtensionInstaller::install\(\) should return React\\Promise\\PromiseInterface<void\|null>|null but return statement is missing\.$~'
             path: 'src/ExtensionInstaller.php'
             count: 3
@@ -41,14 +33,6 @@ parameters:
             count: 1
         -
             message: '~^Short ternary operator is not allowed\. Use null coalesce operator if applicable or consider using long ternary\.$~'
-            path: 'src/ExtensionInstaller.php'
-            count: 1
-        -
-            message: '~^Instantiated class rcube_config not found\.$~'
-            path: 'src/ExtensionInstaller.php'
-            count: 1
-        -
-            message: '~^Call to method resolve_paths\(\) on an unknown class rcube_config\.$~'
             path: 'src/ExtensionInstaller.php'
             count: 1
         -

--- a/src/ExtensionInstaller.php
+++ b/src/ExtensionInstaller.php
@@ -26,6 +26,13 @@ abstract class ExtensionInstaller extends LibraryInstaller
 
     protected function getRoundcubemailInstallPath(): string
     {
+        $rootPackage = $this->composer->getPackage();
+        if ($rootPackage->getName() === 'roundcube/roundcubemail') {
+            $this->initializeVendorDir();
+
+            return dirname($this->vendorDir);
+        }
+
         $roundcubemailPackage = $this->composer
             ->getRepositoryManager()
             ->findPackage('roundcube/roundcubemail', '*');


### PR DESCRIPTION
missed in #47

(Will be) tested in https://github.com/roundcube/roundcubemail/pull/9241.

Unfortunally a new release is needed or v0.3.4 tag needs to be repushed.