### PR TITLE
Use composer InstalledRepository to determine install dir

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,4 +16,4 @@ parameters:
         -
             message: '~^Constant RCMAIL_VERSION not found\.$~'
             path: 'src/ExtensionInstaller.php'
-            count: 3
+            count: 1

--- a/src/ExtensionInstaller.php
+++ b/src/ExtensionInstaller.php
@@ -61,16 +61,19 @@ abstract class ExtensionInstaller extends LibraryInstaller
             . str_replace('/', \DIRECTORY_SEPARATOR, $this->getPackageName($package));
     }
 
-    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    private function initializeRoundcubemailEnvironment(): void
     {
-        $this->setRoundcubemailInstallPath($repo);
-
         // initialize Roundcube environment
         if (!defined('INSTALL_PATH')) {
             define('INSTALL_PATH', $this->getRoundcubemailInstallPath() . '/');
         }
         require_once INSTALL_PATH . 'program/include/iniset.php';
+    }
 
+    public function install(InstalledRepositoryInterface $repo, PackageInterface $package)
+    {
+        $this->setRoundcubemailInstallPath($repo);
+        $this->initializeRoundcubemailEnvironment();
         $this->rcubeVersionCheck($package);
 
         $postInstall = function () use ($package) {
@@ -136,13 +139,7 @@ abstract class ExtensionInstaller extends LibraryInstaller
     public function update(InstalledRepositoryInterface $repo, PackageInterface $initial, PackageInterface $target)
     {
         $this->setRoundcubemailInstallPath($repo);
-
-        // initialize Roundcube environment
-        if (!defined('INSTALL_PATH')) {
-            define('INSTALL_PATH', $this->getRoundcubemailInstallPath() . '/');
-        }
-        require_once INSTALL_PATH . 'program/include/iniset.php';
-
+        $this->initializeRoundcubemailEnvironment();
         $this->rcubeVersionCheck($target);
 
         $extra = $target->getExtra();
@@ -212,12 +209,7 @@ abstract class ExtensionInstaller extends LibraryInstaller
     public function uninstall(InstalledRepositoryInterface $repo, PackageInterface $package)
     {
         $this->setRoundcubemailInstallPath($repo);
-
-        // initialize Roundcube environment
-        if (!defined('INSTALL_PATH')) {
-            define('INSTALL_PATH', $this->getRoundcubemailInstallPath() . '/');
-        }
-        require_once INSTALL_PATH . 'program/include/iniset.php';
+        $this->initializeRoundcubemailEnvironment();
 
         $config = $this->composer->getConfig()->get('roundcube');
 

--- a/src/ExtensionInstaller.php
+++ b/src/ExtensionInstaller.php
@@ -160,7 +160,9 @@ abstract class ExtensionInstaller extends LibraryInstaller
             $package_dir = $this->getInstallPath($target);
 
             // restore persistent files
-            $persistent_files = !empty($extra['roundcube']['persistent-files']) ? $extra['roundcube']['persistent-files'] : ['config.inc.php'];
+            $persistent_files = !empty($extra['roundcube']['persistent-files'])
+                ? $extra['roundcube']['persistent-files']
+                : ['config.inc.php'];
             foreach ($persistent_files as $file) {
                 $path = $temp_dir . \DIRECTORY_SEPARATOR . $file;
                 if (is_readable($path)) {

--- a/src/ExtensionInstaller.php
+++ b/src/ExtensionInstaller.php
@@ -108,12 +108,7 @@ abstract class ExtensionInstaller extends LibraryInstaller
                 if ($sqldir = realpath($package_dir . \DIRECTORY_SEPARATOR . $extra['roundcube']['sql-dir'])) {
                     $this->io->write("<info>Running database initialization script for {$package_name}</info>");
 
-                    $roundcube_version = self::versionNormalize(RCMAIL_VERSION);
-                    if (self::versionCompare($roundcube_version, '1.2.0', '>=')) {
-                        \rcmail_utils::db_init($sqldir);
-                    } else {
-                        throw new \Exception('Database initialization failed. Roundcube 1.2.0 or above required.');
-                    }
+                    \rcmail_utils::db_init($sqldir);
                 }
             }
 
@@ -178,12 +173,7 @@ abstract class ExtensionInstaller extends LibraryInstaller
                 if ($sqldir = realpath($package_dir . \DIRECTORY_SEPARATOR . $extra['roundcube']['sql-dir'])) {
                     $this->io->write("<info>Updating database schema for {$package_name}</info>");
 
-                    $roundcube_version = self::versionNormalize(RCMAIL_VERSION);
-                    if (self::versionCompare($roundcube_version, '1.2.0', '>=')) {
-                        \rcmail_utils::db_update($sqldir, $package_name);
-                    } else {
-                        throw new \Exception('Database update failed. Roundcube 1.2.0 or above required.');
-                    }
+                    \rcmail_utils::db_update($sqldir, $package_name);
                 }
             }
 

--- a/src/PluginInstaller.php
+++ b/src/PluginInstaller.php
@@ -26,7 +26,9 @@ class PluginInstaller extends ExtensionInstaller
 
     protected function getConfig($package_name, $config, $add)
     {
-        $cur_config = !empty($config['plugins']) ? ((array) $config['plugins']) : [];
+        $cur_config = !empty($config['plugins'])
+            ? ((array) $config['plugins'])
+            : [];
         $new_config = $cur_config;
 
         if ($add && !in_array($package_name, $new_config, true)) {
@@ -36,7 +38,9 @@ class PluginInstaller extends ExtensionInstaller
         }
 
         if ($new_config !== $cur_config) {
-            $config_val = count($new_config) > 0 ? "[\n\t'" . implode("',\n\t'", $new_config) . "',\n];" : '[];';
+            $config_val = count($new_config) > 0
+                ? "[\n\t'" . implode("',\n\t'", $new_config) . "',\n];"
+                : '[];';
             $result = ['plugins', $config_val];
         } else {
             $result = false;

--- a/src/SkinInstaller.php
+++ b/src/SkinInstaller.php
@@ -26,7 +26,9 @@ class SkinInstaller extends ExtensionInstaller
 
     protected function getConfig($package_name, $config, $add)
     {
-        $cur_config = !empty($config['skin']) ? $config['skin'] : null;
+        $cur_config = !empty($config['skin'])
+            ? $config['skin']
+            : null;
         $new_config = $cur_config;
 
         if ($add && $new_config !== $package_name) {
@@ -36,7 +38,9 @@ class SkinInstaller extends ExtensionInstaller
         }
 
         if ($new_config !== $cur_config) {
-            $config_val = !empty($new_config) ? "'{$new_config}';" : null;
+            $config_val = !empty($new_config)
+                ? "'{$new_config}';"
+                : null;
             $result = ['skin', $config_val];
         } else {
             $result = false;


### PR DESCRIPTION
based on https://github.com/composer/composer/discussions/11927#discussioncomment-9116893 recommendation

Original `$this->composer->getRepositoryManager()` was wrong, as it searched all composer packages, not only the installed ones ignoring replace/provide composer options leading to possibly wrong path in theory.

I tested installing this installer in Roundcubemail (as composer root package) manually and all went right.